### PR TITLE
feat: add EZE test runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,24 +2,24 @@ name: Build project with Maven
 on:
   pull_request:
   schedule:
-  - cron: '2 2 * * 1-5' # run nightly master builds on weekdays
+    - cron: '2 2 * * 1-5' # run nightly master builds on weekdays
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
-    - name: Java setup
-      uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
-      with:
-        java-version: 11
-    - name: Cache
-      uses: actions/cache@99d99cd262b87f5f8671407a1e5c1ddfa36ad5ba # pin@v1
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Run Maven
-      run: mvn -B clean verify com.mycila:license-maven-plugin:check
+      - name: Checkout
+        uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
+      - name: Java setup
+        uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
+        with:
+          java-version: 17
+      - name: Cache
+        uses: actions/cache@99d99cd262b87f5f8671407a1e5c1ddfa36ad5ba # pin@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Run Maven
+        run: mvn -B clean verify com.mycila:license-maven-plugin:check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,39 +14,39 @@ jobs:
   publish:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
-    - name: Cache
-      uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a # pin@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Set up Java environment
-      uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
-      with:
-        java-version: 11
-        gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
-        gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
-    - name: Deploy SNAPSHOT / Release
-      uses: camunda-community-hub/community-action-maven-release@a9e964bf56978eef9bca81551cecceebb246a8e5 # pin@v1
-      with:
-        release-version: ${{ github.event.release.tag_name }}
-        release-profile: community-action-maven-release
-        nexus-usr: ${{ secrets.NEXUS_USR }}
-        nexus-psw: ${{ secrets.NEXUS_PSW }}
-        maven-usr: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_USR }}
-        maven-psw: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
-        maven-gpg-passphrase: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-      id: release
-    - if: github.event.release
-      name: Attach artifacts to GitHub Release (Release only)
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # pin@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ${{ steps.release.outputs.artifacts_archive_path }}
-        asset_name: ${{ steps.release.outputs.artifacts_archive_path }}
-        asset_content_type: application/zip
+      - uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
+      - name: Cache
+        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a # pin@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Set up Java environment
+        uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
+        with:
+          java-version: 17
+          gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
+          gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
+      - name: Deploy SNAPSHOT / Release
+        uses: camunda-community-hub/community-action-maven-release@a9e964bf56978eef9bca81551cecceebb246a8e5 # pin@v1
+        with:
+          release-version: ${{ github.event.release.tag_name }}
+          release-profile: community-action-maven-release
+          nexus-usr: ${{ secrets.NEXUS_USR }}
+          nexus-psw: ${{ secrets.NEXUS_PSW }}
+          maven-usr: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_USR }}
+          maven-psw: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
+          maven-gpg-passphrase: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        id: release
+      - if: github.event.release
+        name: Attach artifacts to GitHub Release (Release only)
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # pin@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.release.outputs.artifacts_archive_path }}
+          asset_name: ${{ steps.release.outputs.artifacts_archive_path }}
+          asset_content_type: application/zip

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ A tool to write tests for BPMN processes.
 
 Available integrations:
 
-| Workflow Engine | Test Runner Dependency |
-| --- | ---|
-| [Zeebe](https://github.com/camunda-cloud/zeebe)  | `<artifactId>zeebe-test-runner</artifactId>` | 
+| Workflow Engine                                 | Test Runner Dependency                       |
+|-------------------------------------------------|----------------------------------------------|
+| [Zeebe](https://github.com/camunda-cloud/zeebe) | `<artifactId>zeebe-test-runner</artifactId>` | 
 
 ## Usage
 
@@ -56,22 +56,22 @@ _More examples can be found here: https://github.com/zeebe-io/bpmn-tck_
 
 ```kotlin
 val testSpecFulfillCondition =
-  testSpec {
-    resources("exclusive-gateway.bpmn")
+    testSpec {
+        resources("exclusive-gateway.bpmn")
 
-    testCase(
-      name = "fulfill-condition",
-      description = "should fulfill the condition and enter the upper task"
-    ) {
-      actions {
-        createInstance(bpmnProcessId = "exclusive-gateway")
-        completeTask(jobType = "a", variables = mapOf("x" to 8))
-      }
-      verifications {
-        elementInstanceState(selector = byName("B"), state = ElementInstanceState.ACTIVATED)
-      }
-    }
-  };
+        testCase(
+            name = "fulfill-condition",
+            description = "should fulfill the condition and enter the upper task"
+        ) {
+            actions {
+                createInstance(bpmnProcessId = "exclusive-gateway")
+                completeTask(jobType = "a", variables = mapOf("x" to 8))
+            }
+            verifications {
+                elementInstanceState(selector = byName("B"), state = ElementInstanceState.ACTIVATED)
+            }
+        }
+    };
 ```
 
 ### The Spec
@@ -412,3 +412,29 @@ private val specRunner = factory.create(testRunner = ZeebeTestRunner())
 ```
 
 4) Follow the other steps as mentioned [above](#junit-integration-generic)
+
+### JUnit Integration (EzeTestRunner)
+
+This repository contains an integration for JUnit 5 using the extension API. To run the BPMN tests
+against [EZE](https://github.com/camunda-community-hub/eze) (Embedded Zeebe Engine):
+
+1) Add the Maven dependency for the Zeebe test runner:
+
+```
+<!-- running the spec with EZE -->
+<dependency>
+  <groupId>io.zeebe.bpmn-spec</groupId>
+  <artifactId>eze-test-runner</artifactId>
+  <version>${bpmn-spec.version}</version>
+  <scope>test</scope>
+</dependency>
+```    
+
+2) Write a JUnit test class like the one mentioned above and use this line to select
+   the `EzeTestRunner`:
+
+```
+private val specRunner = factory.create(testRunner = EzeTestRunner())
+```
+
+3) Follow the other steps as mentioned [above](#junit-integration-generic)

--- a/eze-test-runner/pom.xml
+++ b/eze-test-runner/pom.xml
@@ -2,47 +2,42 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>root</artifactId>
     <groupId>io.zeebe.bpmn-spec</groupId>
+    <artifactId>root</artifactId>
     <version>2.0.2-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>junit-extension</artifactId>
-
+  <artifactId>eze-test-runner</artifactId>
 
   <dependencies>
-
     <dependency>
       <groupId>io.zeebe.bpmn-spec</groupId>
       <artifactId>core</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <groupId>org.camunda.community</groupId>
+      <artifactId>eze</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.zeebe.bpmn-spec</groupId>
-      <artifactId>zeebe-test-runner</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>io.zeebe.bpmn-spec</groupId>
-      <artifactId>eze-test-runner</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>2.19.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -53,8 +48,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility-kotlin</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/eze-test-runner/src/main/kotlin/io/zeebe/bpmnspec/runner/eze/EzeEnvironment.kt
+++ b/eze-test-runner/src/main/kotlin/io/zeebe/bpmnspec/runner/eze/EzeEnvironment.kt
@@ -1,0 +1,23 @@
+package io.zeebe.bpmnspec.runner.eze
+
+import io.camunda.zeebe.client.ZeebeClient
+import org.camunda.community.eze.EngineFactory
+import org.camunda.community.eze.ZeebeEngine
+
+class EzeEnvironment(
+    val zeebeEngine: ZeebeEngine = EngineFactory.create()
+) {
+
+    lateinit var zeebeClient: ZeebeClient
+
+    fun setup() {
+        zeebeEngine.start()
+
+        zeebeClient = zeebeEngine.createClient()
+    }
+
+    fun cleanUp() {
+        zeebeEngine.stop()
+    }
+
+}

--- a/eze-test-runner/src/main/kotlin/io/zeebe/bpmnspec/runner/eze/EzeProcessInstanceContext.kt
+++ b/eze-test-runner/src/main/kotlin/io/zeebe/bpmnspec/runner/eze/EzeProcessInstanceContext.kt
@@ -1,0 +1,8 @@
+package io.zeebe.bpmnspec.runner.eze
+
+import io.zeebe.bpmnspec.api.ProcessInstanceContext
+
+data class EzeProcessInstanceContext(
+    val processInstanceKey: Long
+) : ProcessInstanceContext {
+}

--- a/eze-test-runner/src/main/kotlin/io/zeebe/bpmnspec/runner/eze/EzeTestContext.kt
+++ b/eze-test-runner/src/main/kotlin/io/zeebe/bpmnspec/runner/eze/EzeTestContext.kt
@@ -1,0 +1,7 @@
+package io.zeebe.bpmnspec.runner.eze
+
+import io.camunda.zeebe.client.ZeebeClient
+
+data class EzeTestContext(
+    val zeebeClient: ZeebeClient
+)

--- a/eze-test-runner/src/main/kotlin/io/zeebe/bpmnspec/runner/eze/EzeTestRunner.kt
+++ b/eze-test-runner/src/main/kotlin/io/zeebe/bpmnspec/runner/eze/EzeTestRunner.kt
@@ -1,0 +1,312 @@
+package io.zeebe.bpmnspec.runner.eze
+
+import io.camunda.zeebe.client.api.worker.JobWorker
+import io.camunda.zeebe.model.bpmn.Bpmn
+import io.camunda.zeebe.model.bpmn.instance.FlowElement
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent
+import io.camunda.zeebe.protocol.record.value.BpmnElementType
+import io.zeebe.bpmnspec.api.ProcessInstanceContext
+import io.zeebe.bpmnspec.api.runner.*
+import org.camunda.community.eze.RecordStream.events
+import org.camunda.community.eze.RecordStream.withElementType
+import org.camunda.community.eze.RecordStream.withKey
+import org.camunda.community.eze.RecordStream.withProcessInstanceKey
+import org.slf4j.LoggerFactory
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.time.Duration
+
+class EzeTestRunner(
+    private val environment: EzeEnvironment = EzeEnvironment(),
+    private val beforeEachCallback: (EzeTestContext) -> Unit = {},
+    private val afterEachCallback: (EzeTestContext) -> Unit = {}
+) : TestRunner {
+
+    private val logger = LoggerFactory.getLogger(EzeTestRunner::class.java)
+
+    private val jobWorkers = mutableListOf<JobWorker>()
+
+    override fun beforeAll() {
+        // nothing to do
+    }
+
+    override fun beforeEach() {
+        logger.debug("Create EZE environment")
+
+        environment.setup()
+
+        beforeEachCallback(EzeTestContext(environment.zeebeClient))
+    }
+
+    override fun afterEach() {
+        logger.debug("Clean up EZE environment")
+
+        jobWorkers.map(JobWorker::close)
+
+        afterEachCallback(EzeTestContext(environment.zeebeClient))
+
+        environment.cleanUp()
+    }
+
+    override fun afterAll() {
+        // nothing to do
+    }
+
+    override fun deployProcess(name: String, bpmnXml: InputStream) {
+        logger.debug("Deploy BPMN process. [name: {}]", name)
+
+        environment.zeebeClient
+            .newDeployResourceCommand()
+            .addResourceStream(bpmnXml, name)
+            .send()
+            .join()
+    }
+
+    override fun createProcessInstance(
+        bpmnProcessId: String,
+        variables: String
+    ): ProcessInstanceContext {
+        logger.debug(
+            "Creating a process instance. [BPMN-process-id: {}, variables: {}]",
+            bpmnProcessId,
+            variables
+        )
+
+        val response = environment.zeebeClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(bpmnProcessId)
+            .latestVersion()
+            .variables(variables)
+            .send()
+            .join()
+
+        return EzeProcessInstanceContext(
+            processInstanceKey = response.processInstanceKey
+        )
+    }
+
+    override fun completeTask(jobType: String, variables: String) {
+        logger.debug(
+            "Start job worker to complete jobs. [job-type: {}, variables: {}]",
+            jobType,
+            variables
+        )
+
+        val jobWorker = environment.zeebeClient
+            .newWorker()
+            .jobType(jobType)
+            .handler { jobClient, job ->
+                jobClient.newCompleteCommand(job.key)
+                    .variables(variables)
+                    .send()
+                    .join()
+            }
+            .timeout(Duration.ofSeconds(1))
+            .open()
+
+        jobWorkers.add(jobWorker)
+    }
+
+    override fun publishMessage(messageName: String, correlationKey: String, variables: String) {
+        logger.debug(
+            "Publish message. [name: {}, correlation-key: {}, variables: {}]",
+            messageName, correlationKey, variables
+        )
+
+        environment.zeebeClient
+            .newPublishMessageCommand()
+            .messageName(messageName)
+            .correlationKey(correlationKey)
+            .variables(variables)
+            .timeToLive(Duration.ofSeconds(10))
+            .send()
+            .join()
+    }
+
+    override fun throwError(jobType: String, errorCode: String, errorMessage: String) {
+        logger.debug(
+            "Start job worker to throw errors. [job-type: {}, error-code: {}, error-message: {}]",
+            jobType, errorCode, errorMessage
+        )
+
+        val jobWorker = environment.zeebeClient
+            .newWorker()
+            .jobType(jobType)
+            .handler { jobClient, job ->
+                jobClient.newThrowErrorCommand(job.key)
+                    .errorCode(errorCode)
+                    .errorMessage(errorMessage)
+                    .send()
+                    .join()
+            }
+            .timeout(Duration.ofSeconds(1))
+            .open()
+
+        jobWorkers.add(jobWorker)
+    }
+
+    override fun cancelProcessInstance(context: ProcessInstanceContext) {
+        val processInstanceContext = context as EzeProcessInstanceContext
+
+        logger.debug(
+            "Cancel process instance. [key: {}]",
+            processInstanceContext.processInstanceKey
+        )
+
+        environment.zeebeClient
+            .newCancelInstanceCommand(processInstanceContext.processInstanceKey)
+            .send()
+            .join()
+    }
+
+    override fun getProcessInstanceContexts(): List<ProcessInstanceContext> {
+        return environment.zeebeEngine
+            .processInstanceRecords()
+            .withElementType(elementType = BpmnElementType.PROCESS)
+            .map { it.value.processInstanceKey }
+            .distinct()
+            .map { EzeProcessInstanceContext(processInstanceKey = it) }
+    }
+
+    override fun getProcessInstanceState(context: ProcessInstanceContext): ProcessInstanceState {
+        val processInstanceContext = context as EzeProcessInstanceContext
+
+        val state = environment.zeebeEngine
+            .processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey = processInstanceContext.processInstanceKey)
+            .withElementType(elementType = BpmnElementType.PROCESS)
+            .map { it.intent }
+            .lastOrNull()
+
+        return when (state) {
+            ProcessInstanceIntent.ELEMENT_ACTIVATED -> ProcessInstanceState.ACTIVATED
+            ProcessInstanceIntent.ELEMENT_COMPLETED -> ProcessInstanceState.COMPLETED
+            ProcessInstanceIntent.ELEMENT_TERMINATED -> ProcessInstanceState.TERMINATED
+            else -> ProcessInstanceState.UNKNOWN
+        }
+    }
+
+    override fun getElementInstances(context: ProcessInstanceContext): List<ElementInstance> {
+        val processInstanceContext = context as EzeProcessInstanceContext
+
+        val elementNameLookup =
+            getElementNameLookup(processInstanceKey = processInstanceContext.processInstanceKey)
+
+        return environment.zeebeEngine
+            .processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey = processInstanceContext.processInstanceKey)
+            .events()
+            .groupBy { it.key }
+            .map { (_, records) ->
+                val lastElementInstanceRecord = records.last()
+                val elementId = lastElementInstanceRecord.value.elementId
+
+                ElementInstance(
+                    elementId = elementId,
+                    elementName = elementNameLookup(elementId),
+                    state = when (lastElementInstanceRecord.intent) {
+                        ProcessInstanceIntent.ELEMENT_ACTIVATED -> ElementInstanceState.ACTIVATED
+                        ProcessInstanceIntent.ELEMENT_COMPLETED -> ElementInstanceState.COMPLETED
+                        ProcessInstanceIntent.ELEMENT_TERMINATED -> ElementInstanceState.TERMINATED
+                        ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN -> ElementInstanceState.TAKEN
+                        else -> ElementInstanceState.UNKNOWN
+                    }
+                )
+            }
+    }
+
+    private fun getElementNameLookup(processInstanceKey: Long): (String) -> String? {
+        val processDefinitionKey = environment.zeebeEngine
+            .processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey = processInstanceKey)
+            .first()
+            .value
+            .processDefinitionKey
+
+        val processRecord = environment.zeebeEngine
+            .processRecords()
+            .withKey(key = processDefinitionKey)
+            .first()
+            .value
+
+        val bpmnXml = processRecord.resource
+
+        val bpmnModelInstance = Bpmn.readModelFromStream(ByteArrayInputStream(bpmnXml))
+
+        return { elementId ->
+            if (elementId == processRecord.bpmnProcessId) {
+                processRecord.bpmnProcessId
+            } else {
+                bpmnModelInstance.getModelElementById<FlowElement>(elementId)
+                    ?.name
+            }
+        }
+    }
+
+    override fun getProcessInstanceVariables(context: ProcessInstanceContext): List<ProcessInstanceVariable> {
+        val processInstanceContext = context as EzeProcessInstanceContext
+
+        val elementNameLookup =
+            getElementNameLookup(processInstanceKey = processInstanceContext.processInstanceKey)
+
+        return environment.zeebeEngine
+            .variableRecords()
+            .withProcessInstanceKey(processInstanceKey = processInstanceContext.processInstanceKey)
+            .events()
+            .groupBy { it.key }
+            .map { (_, records) ->
+                val lastVariableRecordValue = records.last().value
+
+                val scopeKey = lastVariableRecordValue.scopeKey
+                val scopeElementId = getElementId(elementInstanceKey = scopeKey)
+
+                ProcessInstanceVariable(
+                    variableName = lastVariableRecordValue.name,
+                    variableValue = lastVariableRecordValue.value,
+                    scopeElementId = scopeElementId ?: "",
+                    scopeElementName = scopeElementId?.let(elementNameLookup)
+                )
+            }
+    }
+
+    private fun getElementId(elementInstanceKey: Long): String? {
+        return environment.zeebeEngine
+            .processInstanceRecords()
+            .withKey(key = elementInstanceKey)
+            .firstOrNull()
+            ?.value
+            ?.elementId
+    }
+
+    override fun getIncidents(context: ProcessInstanceContext): List<Incident> {
+        val processInstanceContext = context as EzeProcessInstanceContext
+
+        val elementNameLookup =
+            getElementNameLookup(processInstanceKey = processInstanceContext.processInstanceKey)
+
+        return environment.zeebeEngine
+            .incidentRecords()
+            .withProcessInstanceKey(processInstanceKey = processInstanceContext.processInstanceKey)
+            .events()
+            .groupBy { it.key }
+            .map { (_, records) ->
+                val lastIncidentRecord = records.last()
+
+                val incidentElementId =
+                    getElementId(elementInstanceKey = lastIncidentRecord.value.elementInstanceKey)
+
+                Incident(
+                    errorType = lastIncidentRecord.value.errorType.name,
+                    errorMessage = lastIncidentRecord.value.errorMessage,
+                    state = when (lastIncidentRecord.intent) {
+                        IncidentIntent.CREATED -> IncidentState.CREATED
+                        IncidentIntent.RESOLVED -> IncidentState.RESOLVED
+                        else -> IncidentState.UNKNOWN
+                    },
+                    elementId = incidentElementId ?: "?",
+                    elementName = incidentElementId?.let(elementNameLookup)
+                )
+            }
+    }
+}

--- a/eze-test-runner/src/test/kotlin/EzeTestRunnerTest.kt
+++ b/eze-test-runner/src/test/kotlin/EzeTestRunnerTest.kt
@@ -1,0 +1,86 @@
+import io.zeebe.bpmnspec.ClasspathResourceResolver
+import io.zeebe.bpmnspec.SpecRunner
+import io.zeebe.bpmnspec.api.runner.ProcessInstanceState
+import io.zeebe.bpmnspec.runner.eze.EzeTestRunner
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class EzeTestRunnerTest {
+
+    private val resourceResolver =
+        ClasspathResourceResolver(classLoader = EzeTestRunnerTest::class.java.classLoader)
+
+    private val specRunner = SpecRunner(
+        testRunner = EzeTestRunner(),
+        resourceResolver = resourceResolver,
+        verificationTimeout = Duration.ofSeconds(3)
+    )
+
+    @Test
+    fun `should run a YAML spec`() {
+
+        val spec = EzeTestRunnerTest::class.java.getResourceAsStream("/demo-complete-process.yaml")
+        val result = specRunner.runSpec(spec)
+
+        Assertions.assertThat(result.testResults).hasSize(1)
+    }
+
+    @Test
+    fun `should run a YAML spec and publish a message`() {
+
+        val spec = EzeTestRunnerTest::class.java.getResourceAsStream("/demo-publish-message.yaml")
+        val result = specRunner.runSpec(spec)
+
+        Assertions.assertThat(result.testResults).hasSize(1)
+    }
+
+    @Test
+    fun `should run a YAML spec and verify incident`() {
+
+        val spec = EzeTestRunnerTest::class.java.getResourceAsStream("/demo-incident.yaml")
+        val result = specRunner.runSpec(spec)
+
+        Assertions.assertThat(result.testResults).hasSize(1)
+    }
+
+    @Test
+    fun `should fail verification`() {
+
+        val spec = EzeTestRunnerTest::class.java.getResourceAsStream("/demo-fail-verification.yaml")
+        val result = specRunner.runSpec(spec)
+
+        Assertions.assertThat(result.testResults).hasSize(1)
+
+        val testResult = result.testResults[0]
+        Assertions.assertThat(testResult.success).isFalse()
+        Assertions.assertThat(testResult.message)
+            .isEqualTo("Expected the element with name 'B'  to be in state 'COMPLETED' but was 'ACTIVATED'.")
+
+        Assertions.assertThat(testResult.testCase.verifications).hasSize(3)
+        Assertions.assertThat(testResult.successfulVerifications)
+            .containsExactly(testResult.testCase.verifications[0])
+        Assertions.assertThat(testResult.failedVerification)
+            .isEqualTo(testResult.testCase.verifications[1])
+    }
+
+    @Test
+    fun `should collect output`() {
+
+        val spec = EzeTestRunnerTest::class.java.getResourceAsStream("/demo-complete-process.yaml")
+        val result = specRunner.runSpec(spec)
+
+        Assertions.assertThat(result.testResults).hasSize(1)
+
+        val testResult = result.testResults[0]
+        Assertions.assertThat(testResult.success).isTrue()
+        Assertions.assertThat(testResult.output).hasSize(1)
+
+        val testOutput = testResult.output[0];
+        Assertions.assertThat(testOutput.state).isEqualTo(ProcessInstanceState.COMPLETED)
+        Assertions.assertThat(testOutput.elementInstances).hasSize(10)
+        Assertions.assertThat(testOutput.variables).isEmpty()
+        Assertions.assertThat(testOutput.incidents).isEmpty()
+    }
+
+}

--- a/eze-test-runner/src/test/resources/demo-complete-process.yaml
+++ b/eze-test-runner/src/test/resources/demo-complete-process.yaml
@@ -1,0 +1,29 @@
+resources:
+  - demo.bpmn
+
+testCases:
+  - name: complete process
+    description: demo test case
+
+    actions:
+      - action: create-instance
+        args:
+          bpmn_process_id: demo
+          variables: '{}'
+      - action: complete-task
+        args:
+          job_type: a
+          variables: '{}'
+      - action: complete-task
+        args:
+          job_type: b
+          variables: '{}'
+      - action: complete-task
+        args:
+          job_type: c
+          variables: '{}'
+
+    verifications:
+      - verification: process-instance-state
+        args:
+          state: completed

--- a/eze-test-runner/src/test/resources/demo-fail-verification.yaml
+++ b/eze-test-runner/src/test/resources/demo-fail-verification.yaml
@@ -1,0 +1,26 @@
+resources:
+  - demo.bpmn
+
+testCases:
+  - name: fail-verification
+    actions:
+      - action: create-instance
+        args:
+          bpmn_process_id: demo
+      - action: complete-task
+        args:
+          job_type: a
+
+    verifications:
+      - verification: element-instance-state
+        args:
+          element_name: A
+          state: completed
+      - verification: element-instance-state
+        args:
+          element_name: B
+          state: completed
+      - verification: element-instance-state
+        args:
+          element_name: C
+          state: completed

--- a/eze-test-runner/src/test/resources/demo-incident.yaml
+++ b/eze-test-runner/src/test/resources/demo-incident.yaml
@@ -1,0 +1,27 @@
+resources:
+  - demo2.bpmn
+
+testCases:
+  - name: publish message
+
+    actions:
+      - action: create-instance
+        args:
+          bpmn_process_id: demo2
+      - action: complete-task
+        args:
+          job_type: b
+      - action: complete-task
+        args:
+          job_type: c
+
+    verifications:
+      - verification: process-instance-state
+        args:
+          state: activated
+      - verification: incident-state
+        args:
+          error_type: EXTRACT_VALUE_ERROR
+          error_message: "failed to evaluate expression 'key': no variable found for name 'key'"
+          state: created
+          element_name: message-1

--- a/eze-test-runner/src/test/resources/demo-publish-message.yaml
+++ b/eze-test-runner/src/test/resources/demo-publish-message.yaml
@@ -1,0 +1,50 @@
+resources:
+  - demo2.bpmn
+
+testCases:
+  - name: publish message
+
+    actions:
+      - action: create-instance
+        args:
+          bpmn_process_id: demo2
+          variables: '{"key":"key-1"}'
+          process_instance_alias: process-1
+      - action: await-element-instance-state
+        args:
+          element_name: message-1
+          state: activated
+      - action: publish-message
+        args:
+          message_name: message-1
+          correlation_key: key-1
+          variables: '{"x":1}'
+      - action: throw-error
+        args:
+          job_type: b
+          error_code: error-1
+      - action: complete-task
+        args:
+          job_type: c
+          variables: '{}'
+
+    verifications:
+      - verification: process-instance-state
+        args:
+          state: completed
+      - verification: element-instance-state
+        args:
+          element_id: Activity_1g1az2f
+          state: completed
+      - verification: element-instance-state
+        args:
+          element_name: B
+          state: terminated
+      - verification: process-instance-variable
+        args:
+          name: x
+          value: '1'
+      - verification: no-process-instance-variable
+        args:
+          name: x
+          element_name: message-1

--- a/eze-test-runner/src/test/resources/demo.bpmn
+++ b/eze-test-runner/src/test/resources/demo.bpmn
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1qf7pn4" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.9.0">
+  <bpmn:process id="demo" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_127rk0u</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_127rk0u" sourceRef="StartEvent_1" targetRef="Activity_0x0sk1v" />
+    <bpmn:sequenceFlow id="Flow_0lgx9f6" sourceRef="Activity_0x0sk1v" targetRef="Activity_04nignu" />
+    <bpmn:sequenceFlow id="Flow_18omkjs" sourceRef="Activity_04nignu" targetRef="Activity_1ex01ca" />
+    <bpmn:endEvent id="Event_09r6smc">
+      <bpmn:incoming>Flow_1i5dima</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1i5dima" sourceRef="Activity_1ex01ca" targetRef="Event_09r6smc" />
+    <bpmn:serviceTask id="Activity_0x0sk1v" name="A">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="a" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_127rk0u</bpmn:incoming>
+      <bpmn:outgoing>Flow_0lgx9f6</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_04nignu" name="B">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="b" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0lgx9f6</bpmn:incoming>
+      <bpmn:outgoing>Flow_18omkjs</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_1ex01ca" name="C">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="c" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_18omkjs</bpmn:incoming>
+      <bpmn:outgoing>Flow_1i5dima</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="demo">
+      <bpmndi:BPMNEdge id="Flow_127rk0u_di" bpmnElement="Flow_127rk0u">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lgx9f6_di" bpmnElement="Flow_0lgx9f6">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="430" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18omkjs_di" bpmnElement="Flow_18omkjs">
+        <di:waypoint x="530" y="117" />
+        <di:waypoint x="590" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1i5dima_di" bpmnElement="Flow_1i5dima">
+        <di:waypoint x="690" y="117" />
+        <di:waypoint x="752" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_09r6smc_di" bpmnElement="Event_09r6smc">
+        <dc:Bounds x="752" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0p5cl7d_di" bpmnElement="Activity_0x0sk1v">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c8f96y_di" bpmnElement="Activity_04nignu">
+        <dc:Bounds x="430" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0fi9kjl_di" bpmnElement="Activity_1ex01ca">
+        <dc:Bounds x="590" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/eze-test-runner/src/test/resources/demo2.bpmn
+++ b/eze-test-runner/src/test/resources/demo2.bpmn
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_14fm6mk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.9.0">
+  <bpmn:process id="demo2" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_00c9jjh</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_00c9jjh" sourceRef="StartEvent_1" targetRef="Event_0tf6wgs" />
+    <bpmn:intermediateCatchEvent id="Event_0tf6wgs" name="message-1">
+      <bpmn:incoming>Flow_00c9jjh</bpmn:incoming>
+      <bpmn:outgoing>Flow_0d801le</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0pfhf32" messageRef="Message_0vgutwk" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_0d801le" sourceRef="Event_0tf6wgs" targetRef="Activity_1xr2g5d" />
+    <bpmn:serviceTask id="Activity_1xr2g5d" name="B">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="b" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0d801le</bpmn:incoming>
+      <bpmn:outgoing>Flow_08bcz6b</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1lt5rl7">
+      <bpmn:incoming>Flow_08bcz6b</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_08bcz6b" sourceRef="Activity_1xr2g5d" targetRef="Event_1lt5rl7" />
+    <bpmn:boundaryEvent id="Event_0525o8x" name="error-1" attachedToRef="Activity_1xr2g5d">
+      <bpmn:outgoing>Flow_03xf4cj</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0s4hvsv" errorRef="Error_15e181k" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_03xf4cj" sourceRef="Event_0525o8x" targetRef="Activity_1g1az2f" />
+    <bpmn:serviceTask id="Activity_1g1az2f" name="C">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="c" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_03xf4cj</bpmn:incoming>
+      <bpmn:outgoing>Flow_1stsk81</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_0cgr4p4">
+      <bpmn:incoming>Flow_1stsk81</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1stsk81" sourceRef="Activity_1g1az2f" targetRef="Event_0cgr4p4" />
+  </bpmn:process>
+  <bpmn:message id="Message_0vgutwk" name="message-1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:error id="Error_15e181k" name="error-1" errorCode="error-1" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="demo2">
+      <bpmndi:BPMNEdge id="Flow_00c9jjh_di" bpmnElement="Flow_00c9jjh">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="272" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0d801le_di" bpmnElement="Flow_0d801le">
+        <di:waypoint x="308" y="117" />
+        <di:waypoint x="370" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08bcz6b_di" bpmnElement="Flow_08bcz6b">
+        <di:waypoint x="470" y="117" />
+        <di:waypoint x="532" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03xf4cj_di" bpmnElement="Flow_03xf4cj">
+        <di:waypoint x="450" y="175" />
+        <di:waypoint x="450" y="240" />
+        <di:waypoint x="520" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1stsk81_di" bpmnElement="Flow_1stsk81">
+        <di:waypoint x="620" y="240" />
+        <di:waypoint x="672" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1e9zcqt_di" bpmnElement="Event_0tf6wgs">
+        <dc:Bounds x="272" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="263" y="142" width="55" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0asci9m_di" bpmnElement="Activity_1xr2g5d">
+        <dc:Bounds x="370" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1lt5rl7_di" bpmnElement="Event_1lt5rl7">
+        <dc:Bounds x="532" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1phoc4w_di" bpmnElement="Activity_1g1az2f">
+        <dc:Bounds x="520" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cgr4p4_di" bpmnElement="Event_0cgr4p4">
+        <dc:Bounds x="672" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1mq245b_di" bpmnElement="Event_0525o8x">
+        <dc:Bounds x="432" y="139" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="463" y="182" width="33" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/eze-test-runner/src/test/resources/log4j2.xml
+++ b/eze-test-runner/src/test/resources/log4j2.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" strict="true"
+  xmlns="http://logging.apache.org/log4j/2.0/config"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://logging.apache.org/log4j/2.0/config https://raw.githubusercontent.com/apache/logging-log4j2/log4j-2.8.1/log4j-core/src/main/resources/Log4j-config.xsd">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level Java Client: %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="io.zeebe.bpmnspec" level="trace"/>
+
+    <Logger name="io.zeebe" level="info"/>
+
+    <Root level="error">
+      <AppenderRef ref="Console"/>
+    </Root>
+
+
+  </Loggers>
+</Configuration>

--- a/junit-extension/src/test/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecExtensionEzeTest.kt
+++ b/junit-extension/src/test/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecExtensionEzeTest.kt
@@ -1,23 +1,24 @@
 package io.zeebe.bpmnspec.junit
 
-import io.zeebe.bpmnspec.runner.zeebe.ZeebeTestRunner
+import io.zeebe.bpmnspec.runner.eze.EzeTestRunner
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 
 @BpmnSpecRunner
-class BpmnSpecExtensionTest(factory: SpecRunnerFactory) {
+class BpmnSpecExtensionEzeTest(factory: SpecRunnerFactory) {
 
-    private val specRunner = factory.create(testRunner = ZeebeTestRunner())
+    private val specRunner = factory.create(testRunner = EzeTestRunner())
 
     @ParameterizedTest
     @BpmnSpecSource(specResources = ["exclusive-gateway-spec.yaml", "boundary-event-spec.yaml"])
     fun `should pass the BPMN spec`(spec: BpmnSpecTestCase) {
 
-        val testResult = specRunner.runSingleTestCase(resources = spec.resources, testcase = spec.testCase)
+        val testResult =
+            specRunner.runSingleTestCase(resources = spec.resources, testcase = spec.testCase)
 
         assertThat(testResult.success)
-                .describedAs(testResult.message)
-                .isTrue()
+            .describedAs(testResult.message)
+            .isTrue()
     }
 
 }

--- a/junit-extension/src/test/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecExtensionZeebeTest.kt
+++ b/junit-extension/src/test/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecExtensionZeebeTest.kt
@@ -1,0 +1,23 @@
+package io.zeebe.bpmnspec.junit
+
+import io.zeebe.bpmnspec.runner.zeebe.ZeebeTestRunner
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+
+@BpmnSpecRunner
+class BpmnSpecExtensionZeebeTest(factory: SpecRunnerFactory) {
+
+    private val specRunner = factory.create(testRunner = ZeebeTestRunner())
+
+    @ParameterizedTest
+    @BpmnSpecSource(specResources = ["exclusive-gateway-spec.yaml", "boundary-event-spec.yaml"])
+    fun `should pass the BPMN spec`(spec: BpmnSpecTestCase) {
+
+        val testResult = specRunner.runSingleTestCase(resources = spec.resources, testcase = spec.testCase)
+
+        assertThat(testResult.success)
+                .describedAs(testResult.message)
+                .isTrue()
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.zeebe.bpmn-spec</groupId>
@@ -15,18 +17,20 @@
     <artifactId>camunda-release-parent</artifactId>
     <version>3.9.1</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <modules>
     <module>core</module>
     <module>zeebe-test-runner</module>
     <module>junit-extension</module>
+    <module>eze-test-runner</module>
   </modules>
 
   <properties>
     <kotlin.version>1.8.0</kotlin.version>
     <zeebe.version>8.1.5</zeebe.version>
+    <eze.version>1.1.0</eze.version>
 
     <junit.version>5.9.1</junit.version>
 
@@ -64,11 +68,23 @@
       </dependency>
 
       <dependency>
+        <groupId>io.zeebe.bpmn-spec</groupId>
+        <artifactId>eze-test-runner</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-bom</artifactId>
         <version>${zeebe.version}</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+
+      <dependency>
+        <groupId>org.camunda.community</groupId>
+        <artifactId>eze</artifactId>
+        <version>${eze.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Add a new test runner for [EZE](https://github.com/camunda-community-hub/eze) (Embedded Zeebe Engine). The runner is similar to the Zeebe runner but much faster (< 1s vs. 25s).

It runs the test cases in an embedded Zeebe engine that is created for each test case. The state is extracted directly from the records.

closes #100 