### PR TITLE
deps: Switch version of slf4j-api back to 1.7.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>2.0.6</version>
+        <version>1.7.36</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Previously the version of `slfj4-api` was dumped to `2.0.6`. But this version update disabled the logging. The version of `log4j` is not compatible with `slfj4` in version 2. As a result, the logging was disabled.

Switch the version of `slf4j-api` back to `1.7.36` that is compatible with `log4j`.