### PR TITLE
feat: JUnit extension injects Zeebe client

### DIFF
--- a/junit-extension/src/main/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecRunner.kt
+++ b/junit-extension/src/main/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecRunner.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-@ExtendWith(SpecRunnerProvider::class)
+@ExtendWith(SpecRunnerProvider::class, SpecRunnerInjectCallback::class)
 annotation class BpmnSpecRunner(
     val resourceDirectory: String = "",
     val verificationTimeout: String = "PT10S",

--- a/junit-extension/src/main/kotlin/io/zeebe/bpmnspec/junit/SpecRunnerInjectCallback.kt
+++ b/junit-extension/src/main/kotlin/io/zeebe/bpmnspec/junit/SpecRunnerInjectCallback.kt
@@ -1,0 +1,61 @@
+package io.zeebe.bpmnspec.junit
+
+import io.camunda.zeebe.client.ZeebeClient
+import io.zeebe.bpmnspec.api.SpecTestRunnerContext
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.platform.commons.util.ExceptionUtils
+import org.junit.platform.commons.util.ReflectionUtils
+import java.lang.reflect.Field
+import kotlin.reflect.KClass
+
+class SpecRunnerInjectCallback : BeforeEachCallback {
+
+    override fun beforeEach(context: ExtensionContext?) {
+        context
+            ?.requiredTestInstances
+            ?.allInstances
+            ?.forEach {
+                injectFields(context, it, it.javaClass)
+            }
+    }
+
+    private fun injectFields(context: ExtensionContext, testInstance: Any, testClass: Class<*>) {
+
+        val specTestRunnerContext = context
+            .getStore(SpecRunnerProvider.extensionContextNamespace)
+            .get(SpecRunnerProvider.extensionContextStoreKey, SpecTestRunnerContext::class.java)
+            ?: throw RuntimeException("Expect spec test runner context but not found")
+
+        injectFields(
+            specTestRunnerContext,
+            testInstance,
+            testClass,
+            ZeebeClient::class
+        ) { it.getZeebeClient() }
+    }
+
+    private fun injectFields(
+        specTestRunnerContext: SpecTestRunnerContext,
+        testInstance: Any,
+        testClass: Class<*>,
+        fieldType: KClass<*>,
+        fieldValue: (SpecTestRunnerContext) -> Any
+    ) {
+        val fields = ReflectionUtils.findFields(
+            testClass,
+            { field: Field -> ReflectionUtils.isNotStatic(field) && field.type == fieldType.java },
+            ReflectionUtils.HierarchyTraversalMode.TOP_DOWN
+        )
+
+        fields.forEach { field: Field ->
+            try {
+                ReflectionUtils.makeAccessible(field)[testInstance] =
+                    fieldValue(specTestRunnerContext)
+            } catch (t: Throwable) {
+                ExceptionUtils.throwAsUncheckedException(t)
+            }
+        }
+    }
+
+}

--- a/junit-extension/src/test/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecExtensionInjectionTest.kt
+++ b/junit-extension/src/test/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecExtensionInjectionTest.kt
@@ -1,0 +1,46 @@
+package io.zeebe.bpmnspec.junit
+
+import io.camunda.zeebe.client.ZeebeClient
+import io.zeebe.bpmnspec.SpecRunner
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+
+@BpmnSpecRunner(verificationTimeout = "PT1S")
+class BpmnSpecExtensionInjectionTest(private val specRunner: SpecRunner) {
+
+    private lateinit var zeebeClient: ZeebeClient
+
+    @BeforeEach
+    fun `start external worker`() {
+        zeebeClient.newWorker()
+            .jobType("a")
+            .handler { client, job ->
+                val valueOfX = job.variablesAsMap["x"] as Int
+                val newValue = valueOfX + 1
+
+                client.newCompleteCommand(job.key)
+                    .variables(mapOf("x" to newValue))
+                    .send()
+                    .join()
+            }
+            .open()
+    }
+
+    @ParameterizedTest
+    @BpmnSpecSource(specResources = ["spec-with-external-worker.yaml"])
+    fun `should inject Zeebe client and complete process`(spec: BpmnSpecTestCase) {
+
+        assertThat(zeebeClient)
+            .describedAs("Zeebe client should be injected")
+            .isNotNull()
+
+        val testResult =
+            specRunner.runSingleTestCase(resources = spec.resources, testcase = spec.testCase)
+
+        assertThat(testResult.success)
+            .describedAs(testResult.message)
+            .isTrue()
+    }
+
+}

--- a/junit-extension/src/test/resources/spec-with-external-worker.yaml
+++ b/junit-extension/src/test/resources/spec-with-external-worker.yaml
@@ -1,0 +1,31 @@
+resources:
+  - exclusive-gateway.bpmn
+
+testCases:
+  - name: activate task B
+    description: the external job worker should complete task A with 'x' > 5
+    actions:
+      - action: create-instance
+        args:
+          bpmn_process_id: exclusive-gateway
+          variables: '{"x":5}'
+
+    verifications:
+      - verification: element-instance-state
+        args:
+          element_name: B
+          state: activated
+
+  - name: activate task C
+    description: the external job worker should complete task A with 'x' <= 5
+    actions:
+      - action: create-instance
+        args:
+          bpmn_process_id: exclusive-gateway
+          variables: '{"x":3}'
+
+    verifications:
+      - verification: element-instance-state
+        args:
+          element_name: C
+          state: activated


### PR DESCRIPTION
If the test class has a field with the type of the Zeebe client then the JUnit extension injects a Zeebe client for the current test run.

The injection can be used to start an external job worker or a process application for the test run.

```
@BpmnSpecRunner
class BpmnSpecExtensionInjectionTest(private val specRunner: SpecRunner) {

    private lateinit var zeebeClient: ZeebeClient

    @BeforeEach
    fun `start external worker`() {
        zeebeClient.newWorker()
            .jobType("task-a")
            .handler { client, job ->
                client.newCompleteCommand(job.key)
                    .variables(mapOf("a" to 5))
                    .send()
                    .join()
            }
            .open()
    }

}
```