### PR TITLE
feat: add AssertJ assertion for test result

### DIFF
--- a/junit-extension/pom.xml
+++ b/junit-extension/pom.xml
@@ -37,7 +37,6 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/junit-extension/src/main/kotlin/io/zeebe/bpmnspec/assertj/SpecAssertions.kt
+++ b/junit-extension/src/main/kotlin/io/zeebe/bpmnspec/assertj/SpecAssertions.kt
@@ -1,0 +1,10 @@
+package io.zeebe.bpmnspec.assertj
+
+import io.zeebe.bpmnspec.api.TestResult
+
+object SpecAssertions {
+
+    fun assertThat(actual: TestResult): SpecTestResultAssert =
+        SpecTestResultAssert.assertThat(actual = actual)
+
+}

--- a/junit-extension/src/main/kotlin/io/zeebe/bpmnspec/assertj/SpecTestResultAssert.kt
+++ b/junit-extension/src/main/kotlin/io/zeebe/bpmnspec/assertj/SpecTestResultAssert.kt
@@ -1,0 +1,59 @@
+package io.zeebe.bpmnspec.assertj
+
+import io.zeebe.bpmnspec.api.TestOutput
+import io.zeebe.bpmnspec.api.TestResult
+import org.assertj.core.api.AbstractAssert
+
+class SpecTestResultAssert(actual: TestResult) :
+    AbstractAssert<SpecTestResultAssert, TestResult>(actual, SpecTestResultAssert::class.java) {
+
+    companion object {
+        fun assertThat(actual: TestResult): SpecTestResultAssert =
+            SpecTestResultAssert(actual = actual)
+    }
+
+    fun isSuccessful(): SpecTestResultAssert {
+        isNotNull()
+
+        if (!actual.success) {
+            val testOutput = actual.output.joinToString(separator = "\n") {
+                formatTestOutput(it)
+            }
+
+            failWithMessage(
+                """
+                %s
+                
+                Test output:
+                ============
+                
+                %s
+            """.trimIndent(), actual.message, testOutput
+            )
+        }
+
+        return this
+    }
+
+    private fun formatTestOutput(testOutput: TestOutput): String {
+
+        val elementInstances = testOutput.elementInstances.map { instance ->
+            "\t- '${instance.elementName ?: instance.elementId}': ${instance.state}"
+        }.joinToString(separator = "\n", prefix = "\n")
+
+        val variables = testOutput.variables.map { variable ->
+            "\t- '${variable.variableName}': '${variable.variableValue}' [scope: '${variable.scopeElementName ?: variable.scopeElementId}']"
+        }.joinToString(separator = "\n", prefix = "\n")
+
+        val incidents = testOutput.incidents.map { incident ->
+            "\t- ${incident.errorType}: '${incident.errorMessage}' [state: ${incident.state}, scope: '${incident.elementName ?: incident.elementId}']"
+        }.joinToString(separator = "\n", prefix = "\n")
+
+        return """Process instance key: ${testOutput.processInstanceKey}
+                        |State: ${testOutput.state}
+                        |Element instances: $elementInstances
+                        |Variables: $variables
+                        |Incidents: $incidents""".trimMargin()
+    }
+
+}

--- a/junit-extension/src/test/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecExtensionTest.kt
+++ b/junit-extension/src/test/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecExtensionTest.kt
@@ -1,7 +1,7 @@
 package io.zeebe.bpmnspec.junit
 
 import io.zeebe.bpmnspec.SpecRunner
-import org.assertj.core.api.Assertions.assertThat
+import io.zeebe.bpmnspec.assertj.SpecAssertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 
 @BpmnSpecRunner
@@ -14,9 +14,7 @@ class BpmnSpecExtensionTest(private val specRunner: SpecRunner) {
         val testResult =
             specRunner.runSingleTestCase(resources = spec.resources, testcase = spec.testCase)
 
-        assertThat(testResult.success)
-            .describedAs(testResult.message)
-            .isTrue()
+        assertThat(testResult).isSuccessful()
     }
 
 }


### PR DESCRIPTION
## Description 

Introduce a custom AssertJ assertion in the JUnit module. It can be used to verify that the test result is successful. If not, it prints the failed verification and the whole test output.

```
import io.zeebe.bpmnspec.assertj.SpecAssertions.assertThat

@BpmnSpecRunner
class BpmnSpecExtensionTest(private val specRunner: SpecRunner) {
   
    @ParameterizedTest
    @BpmnSpecSource(specResources = ["exclusive-gateway-spec.yaml", "boundary-event-spec.yaml"])
    fun `should pass the BPMN spec`(spec: BpmnSpecTestCase) {
        val testResult =
            specRunner.runSingleTestCase(resources = spec.resources, testcase = spec.testCase)

        assertThat(testResult).isSuccessful()
    }

}
```

closes #142 