### PR TITLE
feat: load spec resources from directory

### DIFF
--- a/junit-extension/src/main/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecSource.kt
+++ b/junit-extension/src/main/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecSource.kt
@@ -2,9 +2,14 @@ package io.zeebe.bpmnspec.junit
 
 import org.junit.jupiter.params.provider.ArgumentsSource
 
+/**
+ * The spec source must define either a list of spec resources of a directory that contains the spec
+ * resources. The spec resources are loaded from the classpath.
+ */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 @ArgumentsSource(BpmnSpecTestCaseArgumentsProvider::class)
 annotation class BpmnSpecSource(
-        val specResources: Array<String>
+    val specResources: Array<String> = [],
+    val specDirectory: String = ""
 )

--- a/junit-extension/src/main/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecTestCaseArgumentsProvider.kt
+++ b/junit-extension/src/main/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecTestCaseArgumentsProvider.kt
@@ -5,7 +5,11 @@ import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.support.AnnotationConsumer
+import java.io.FileInputStream
+import java.io.InputStream
+import java.nio.file.Path
 import java.util.stream.Stream
+import kotlin.io.path.isDirectory
 
 
 class BpmnSpecTestCaseArgumentsProvider : ArgumentsProvider, AnnotationConsumer<BpmnSpecSource> {
@@ -13,37 +17,75 @@ class BpmnSpecTestCaseArgumentsProvider : ArgumentsProvider, AnnotationConsumer<
     private val specDeserializer = SpecDeserializer()
 
     private val specResources = mutableListOf<String>()
+    private var specDirectory: String? = null
 
     override fun accept(specSource: BpmnSpecSource?) {
-        specSource?.specResources?.forEach { specResources.add(it) }
-                ?: throw RuntimeException("annotation @BpmnSpecSource no found")
+        specSource?.let { source ->
+            source.specResources.forEach { resource -> specResources.add(resource) }
+            source.specDirectory.takeIf { it.isNotEmpty() }.let { specDirectory = it }
+        }
+            ?: throw RuntimeException("annotation @BpmnSpecSource no found")
     }
 
     override fun provideArguments(extensionContext: ExtensionContext?): Stream<out Arguments> {
+        validateArguments()
 
-        if (specResources.isEmpty()) {
-            throw RuntimeException("no spec resources defined")
+        return getResources(extensionContext)
+            .map { resource -> specDeserializer.readSpec(resource) }
+            .flatMap { spec ->
+                spec.testCases.map {
+                    BpmnSpecTestCase(
+                        resources = spec.resources,
+                        testCase = it
+                    )
+                }
+            }
+            .map { Arguments.of(it) }
+            .stream()
+    }
+
+    private fun validateArguments() {
+        if (specResources.isEmpty() && specDirectory == null) {
+            throw RuntimeException("No spec resources or directory defined.")
         }
 
-        return specResources
+        if (specResources.isNotEmpty() && specDirectory != null) {
+            throw RuntimeException("Both spec resources AND a directory are defined. But it can be either spec resources OR a directory.")
+        }
+    }
+
+    private fun getResources(extensionContext: ExtensionContext?): List<InputStream> {
+        if (specResources.isNotEmpty()) {
+            return specResources
                 .map { specResource ->
                     extensionContext
-                            ?.testClass
-                            ?.map { it.classLoader.getResourceAsStream(specResource) }
-                            ?.orElseThrow { RuntimeException("no spec resource found with name '$specResource' in classpath") }
-                            ?: throw RuntimeException("extension context not found")
+                        ?.testClass
+                        ?.map { it.classLoader.getResourceAsStream(specResource) }
+                        ?.orElseThrow { RuntimeException("No spec resource found with name '$specResource' in classpath") }
+                        ?: throw RuntimeException("Extension context not found")
                 }
-                .map { resource -> specDeserializer.readSpec(resource) }
-                .flatMap { spec ->
-                    spec.testCases.map {
-                        BpmnSpecTestCase(
-                                resources = spec.resources,
-                                testCase = it
-                        )
+        }
+
+        if (specDirectory != null) {
+            return specDirectory?.let { directory ->
+                extensionContext
+                    ?.testClass
+                    ?.map { it.classLoader.getResource(specDirectory) }
+                    ?.map { Path.of(it.toURI()) }
+                    ?.filter { it.isDirectory() }
+                    ?.map { dir ->
+                        dir.toFile().listFiles { _, name -> name.endsWith(".yaml") }
+                            ?.takeIf { it.isNotEmpty() }
+                            ?.toList()
+                            ?.map { FileInputStream(it) }
+                            ?: throw RuntimeException("The spec directory with name '$directory' is empty. It must contain at least one spec resource.")
                     }
-                }
-                .map { Arguments.of(it) }
-                .stream()
+                    ?.orElseThrow { RuntimeException("No spec directory found with name '$directory' in classpath") }
+                    ?: throw RuntimeException("Extension context not found")
+            } ?: throw RuntimeException("No spec directory found")
+        }
+
+        throw RuntimeException("No spec resource provider found")
     }
 
 }

--- a/junit-extension/src/test/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecExtensionTest.kt
+++ b/junit-extension/src/test/kotlin/io/zeebe/bpmnspec/junit/BpmnSpecExtensionTest.kt
@@ -17,4 +17,14 @@ class BpmnSpecExtensionTest(private val specRunner: SpecRunner) {
         assertThat(testResult).isSuccessful()
     }
 
+    @ParameterizedTest
+    @BpmnSpecSource(specDirectory = "specs")
+    fun `should run all specs in directory`(spec: BpmnSpecTestCase) {
+
+        val testResult =
+            specRunner.runSingleTestCase(resources = spec.resources, testcase = spec.testCase)
+
+        assertThat(testResult).isSuccessful()
+    }
+
 }

--- a/junit-extension/src/test/resources/specs/spec1.yaml
+++ b/junit-extension/src/test/resources/specs/spec1.yaml
@@ -1,0 +1,34 @@
+resources:
+  - demo.bpmn
+
+testCases:
+  - name: spec 1 - case 1
+    description: should activate task A
+
+    actions:
+      - action: create-instance
+        args:
+          bpmn_process_id: demo
+
+    verifications:
+      - verification: element-instance-state
+        args:
+          element_name: A
+          state: activated
+
+  - name: spec 1 - case 2
+    description: should complete task A
+
+    actions:
+      - action: create-instance
+        args:
+          bpmn_process_id: demo
+      - action: complete-task
+        args:
+          job_type: a
+
+    verifications:
+      - verification: element-instance-state
+        args:
+          element_name: A
+          state: completed

--- a/junit-extension/src/test/resources/specs/spec2.yaml
+++ b/junit-extension/src/test/resources/specs/spec2.yaml
@@ -1,0 +1,20 @@
+resources:
+  - demo.bpmn
+
+testCases:
+  - name: spec 2 - case 1
+    description: should activate task B
+
+    actions:
+      - action: create-instance
+        args:
+          bpmn_process_id: demo
+      - action: complete-task
+        args:
+          job_type: a
+
+    verifications:
+      - verification: element-instance-state
+        args:
+          element_name: B
+          state: activated


### PR DESCRIPTION
## Description

Extend the `@BpmnSpecSource` annotation for JUnit to accept a directory that contains the spec resources. This is an alternative to the specification of all spec resources explicitly.

```
@BpmnSpecRunner
class BpmnSpecExtensionTest(private val specRunner: SpecRunner) {

    @ParameterizedTest
    @BpmnSpecSource(specDirectory = "specs")
    fun `should run all specs in directory`(spec: BpmnSpecTestCase) {

        val testResult =
            specRunner.runSingleTestCase(resources = spec.resources, testcase = spec.testCase)

        assertThat(testResult).isSuccessful()
    }

}
```